### PR TITLE
feat: implementar ativação/inativação de produtos e refatorar relação produto-categoria

### DIFF
--- a/lib/data/models/categoria_model.dart
+++ b/lib/data/models/categoria_model.dart
@@ -14,10 +14,14 @@ class CategoriaModel extends Categoria {
   @HiveField(2)
   int ordem;
 
+  @HiveField(3, defaultValue: [])
+  List<String> produtoIds;
+
   CategoriaModel({
     required this.id,
     required this.nome,
     required this.ordem,
+    this.produtoIds = const [],
   }) : super(id: id, nome: nome, ordem: ordem);
 
   factory CategoriaModel.fromEntity(Categoria categoria) {
@@ -25,6 +29,9 @@ class CategoriaModel extends Categoria {
       id: categoria.id,
       nome: categoria.nome,
       ordem: categoria.ordem,
+
+      // Se a entidade tiver a lista, passe-a. Caso contrário, use uma lista vazia.
+      produtoIds: (categoria is CategoriaModel) ? categoria.produtoIds : [],
     );
   }
 }

--- a/lib/data/models/categoria_model.g.dart
+++ b/lib/data/models/categoria_model.g.dart
@@ -20,19 +20,22 @@ class CategoriaModelAdapter extends TypeAdapter<CategoriaModel> {
       id: fields[0] as String,
       nome: fields[1] as String,
       ordem: fields[2] as int,
+      produtoIds: fields[3] == null ? [] : (fields[3] as List).cast<String>(),
     );
   }
 
   @override
   void write(BinaryWriter writer, CategoriaModel obj) {
     writer
-      ..writeByte(3)
+      ..writeByte(4)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
       ..write(obj.nome)
       ..writeByte(2)
-      ..write(obj.ordem);
+      ..write(obj.ordem)
+      ..writeByte(3)
+      ..write(obj.produtoIds);
   }
 
   @override

--- a/lib/data/models/produto_model.dart
+++ b/lib/data/models/produto_model.dart
@@ -17,12 +17,21 @@ class ProdutoModel extends Produto {
   @HiveField(3)
   String categoriaId;
 
+  @HiveField(4, defaultValue: true)
+  bool isAtivo;
+
   ProdutoModel({
     required this.id,
     required this.nome,
     this.preco = 0.0,
     required this.categoriaId,
-  }) : super(id: id, nome: nome, preco: preco, categoriaId: categoriaId);
+    this.isAtivo = true,
+  }) : super(
+            id: id,
+            nome: nome,
+            preco: preco,
+            categoriaId: categoriaId,
+            isAtivo: isAtivo);
 
   factory ProdutoModel.fromEntity(Produto produto) {
     return ProdutoModel(
@@ -30,6 +39,7 @@ class ProdutoModel extends Produto {
       nome: produto.nome,
       preco: produto.preco,
       categoriaId: produto.categoriaId,
+      isAtivo: produto.isAtivo,
     );
   }
 }

--- a/lib/data/models/produto_model.g.dart
+++ b/lib/data/models/produto_model.g.dart
@@ -21,13 +21,14 @@ class ProdutoModelAdapter extends TypeAdapter<ProdutoModel> {
       nome: fields[1] as String,
       preco: fields[2] as double,
       categoriaId: fields[3] as String,
+      isAtivo: fields[4] == null ? true : fields[4] as bool,
     );
   }
 
   @override
   void write(BinaryWriter writer, ProdutoModel obj) {
     writer
-      ..writeByte(4)
+      ..writeByte(5)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -35,7 +36,9 @@ class ProdutoModelAdapter extends TypeAdapter<ProdutoModel> {
       ..writeByte(2)
       ..write(obj.preco)
       ..writeByte(3)
-      ..write(obj.categoriaId);
+      ..write(obj.categoriaId)
+      ..writeByte(4)
+      ..write(obj.isAtivo);
   }
 
   @override

--- a/lib/data/repositories/gestao_repository_impl.dart
+++ b/lib/data/repositories/gestao_repository_impl.dart
@@ -50,6 +50,7 @@ class GestaoRepositoryImpl implements IGestaoRepository {
             nome: prodData['nome'],
             preco: (prodData['preco'] as double?) ?? 0.0,
             categoriaId: catId,
+            isAtivo: (prodData['isAtivo'] as bool?) ?? true,
           );
           await prodBox.put(prodId, newProd);
         }
@@ -172,6 +173,16 @@ class GestaoRepositoryImpl implements IGestaoRepository {
     final produto = box.get(produtoId);
     if (produto != null) {
       produto.nome = novoNome;
+      await box.put(produtoId, produto);
+    }
+  }
+
+  @override
+  Future<void> atualizarStatusProduto(String produtoId, bool isAtivo) async {
+    final box = Hive.box<ProdutoModel>(_produtosBox);
+    final produto = box.get(produtoId);
+    if (produto != null) {
+      produto.isAtivo = isAtivo;
       await box.put(produtoId, produto);
     }
   }

--- a/lib/data/repositories/gestao_repository_impl.dart
+++ b/lib/data/repositories/gestao_repository_impl.dart
@@ -38,13 +38,13 @@ class GestaoRepositoryImpl implements IGestaoRepository {
     int catOrder = 0;
     for (var catData in seedData) {
       final catId = _uuid.v4();
-      final newCat =
-          CategoriaModel(id: catId, nome: catData['nome'], ordem: catOrder++);
-      await catBox.put(catId, newCat);
+      final List<String> produtoIds = [];
 
       if (catData['produtos'] != null) {
         for (var prodData in (catData['produtos'] as List)) {
           final prodId = _uuid.v4();
+          produtoIds.add(prodId);
+
           final newProd = ProdutoModel(
             id: prodId,
             nome: prodData['nome'],
@@ -55,6 +55,14 @@ class GestaoRepositoryImpl implements IGestaoRepository {
           await prodBox.put(prodId, newProd);
         }
       }
+
+      final newCat = CategoriaModel(
+        id: catId,
+        nome: catData['nome'],
+        ordem: catOrder++,
+        produtoIds: produtoIds,
+      );
+      await catBox.put(catId, newCat);
     }
   }
 
@@ -91,16 +99,14 @@ class GestaoRepositoryImpl implements IGestaoRepository {
 
   @override
   Future<void> deletarCategoria(String categoriaId) async {
-    final boxCategorias = Hive.box<CategoriaModel>(_categoriasBox);
-    final boxProdutos = Hive.box<ProdutoModel>(_produtosBox);
+    final categoriasBox = Hive.box<CategoriaModel>(_categoriasBox);
+    final produtosBox = Hive.box<ProdutoModel>(_produtosBox);
 
-    final produtosParaDeletar =
-        boxProdutos.values.where((p) => p.categoriaId == categoriaId).toList();
+    final categoria = categoriasBox.get(categoriaId);
+    if (categoria == null) return;
 
-    final chavesDosProdutos = produtosParaDeletar.map((p) => p.id).toList();
-
-    await boxProdutos.deleteAll(chavesDosProdutos);
-    await boxCategorias.delete(categoriaId);
+    await produtosBox.deleteAll(categoria.produtoIds);
+    await categoriasBox.delete(categoriaId);
   }
 
   @override
@@ -118,22 +124,33 @@ class GestaoRepositoryImpl implements IGestaoRepository {
 
   @override
   Future<void> criarProduto(String nome, String categoriaId) async {
-    final box = Hive.box<ProdutoModel>(_produtosBox);
+    final produtosBox = Hive.box<ProdutoModel>(_produtosBox);
+    final categoriasBox = Hive.box<CategoriaModel>(_categoriasBox);
     final novoId = _uuid.v4();
 
-    final novoProduto = ProdutoModel(
-      id: novoId,
-      nome: nome,
-      categoriaId: categoriaId,
-    );
-    await box.put(novoId, novoProduto);
+    final novoProduto =
+        ProdutoModel(id: novoId, nome: nome, categoriaId: categoriaId);
+    await produtosBox.put(novoId, novoProduto);
+
+    final categoria = categoriasBox.get(categoriaId);
+    if (categoria != null) {
+      categoria.produtoIds.add(novoId);
+      await categoriasBox.put(categoriaId, categoria);
+    }
   }
 
   @override
   List<Produto> getProdutosPorCategoria(String categoriaId) {
-    final box = Hive.box<ProdutoModel>(_produtosBox);
-    return box.values
-        .where((produto) => produto.categoriaId == categoriaId)
+    final produtosBox = Hive.box<ProdutoModel>(_produtosBox);
+    final categoriasBox = Hive.box<CategoriaModel>(_categoriasBox);
+
+    final categoria = categoriasBox.get(categoriaId);
+    if (categoria == null) return [];
+
+    return categoria.produtoIds
+        .map((id) => produtosBox.get(id))
+        .where((produto) => produto != null)
+        .cast<Produto>()
         .toList();
   }
 
@@ -156,15 +173,30 @@ class GestaoRepositoryImpl implements IGestaoRepository {
 
   @override
   Future<void> deletarProduto(String produtoId, String categoriaId) async {
-    final box = Hive.box<ProdutoModel>(_produtosBox);
-    await box.delete(produtoId);
+    final produtosBox = Hive.box<ProdutoModel>(_produtosBox);
+    final categoriasBox = Hive.box<CategoriaModel>(_categoriasBox);
+    await produtosBox.delete(produtoId);
+
+    final categoria = categoriasBox.get(categoriaId);
+    if (categoria != null) {
+      categoria.produtoIds.remove(produtoId);
+      await categoriasBox.put(categoriaId, categoria);
+    }
   }
 
   @override
   Future<void> adicionarProdutoObjeto(Produto produto) async {
-    final box = Hive.box<ProdutoModel>(_produtosBox);
+    final produtosBox = Hive.box<ProdutoModel>(_produtosBox);
+    final categoriasBox = Hive.box<CategoriaModel>(_categoriasBox);
     final produtoModel = ProdutoModel.fromEntity(produto);
-    await box.put(produtoModel.id, produtoModel);
+
+    await produtosBox.put(produtoModel.id, produtoModel);
+
+    final categoria = categoriasBox.get(produto.categoriaId);
+    if (categoria != null && !categoria.produtoIds.contains(produto.id)) {
+      categoria.produtoIds.add(produto.id);
+      await categoriasBox.put(produto.categoriaId, categoria);
+    }
   }
 
   @override

--- a/lib/domain/entities/produto.dart
+++ b/lib/domain/entities/produto.dart
@@ -3,11 +3,13 @@ class Produto {
   String nome;
   double preco;
   String categoriaId;
+  bool isAtivo;
 
   Produto({
     required this.id,
     required this.nome,
     this.preco = 0.0,
     required this.categoriaId,
+    this.isAtivo = true,
   });
 }

--- a/lib/domain/repositories/i_gestao_repository.dart
+++ b/lib/domain/repositories/i_gestao_repository.dart
@@ -49,4 +49,7 @@ abstract class IGestaoRepository {
 
   /// Atualiza o nome de um produto existente.
   Future<void> atualizarNomeProduto(String produtoId, String novoNome);
+
+  /// Atualiza o status de um produto (ativo/inativo).
+  Future<void> atualizarStatusProduto(String produtoId, bool isAtivo);
 }

--- a/lib/domain/usecases/produto/update_produto_status.dart
+++ b/lib/domain/usecases/produto/update_produto_status.dart
@@ -1,0 +1,12 @@
+import '../../../domain/repositories/i_gestao_repository.dart';
+
+/// Caso de uso para atualizar o status de um produto.
+class UpdateProdutoStatus {
+  final IGestaoRepository repository;
+
+  UpdateProdutoStatus(this.repository);
+
+  Future<void> call({required String id, required bool isAtivo}) {
+    return repository.atualizarStatusProduto(id, isAtivo);
+  }
+}

--- a/lib/presentation/gestao_produtos/gestao_page.dart
+++ b/lib/presentation/gestao_produtos/gestao_page.dart
@@ -5,7 +5,7 @@ import 'package:precifica/data/profiles.dart';
 import 'package:share_plus/share_plus.dart';
 
 // Importando as entidades do domínio
-import '../../domain/entities/produto.dart';
+import 'package:precifica/domain/entities/produto.dart';
 
 // Importando o controller e o state da camada de apresentação
 import 'gestao_controller.dart';
@@ -353,6 +353,10 @@ class _GestaoPageState extends ConsumerState<GestaoPage> {
                                 produto.id, novoNome);
                           },
                         );
+                      },
+                      onProdutoTap: (produto) {
+                        gestaoNotifier.atualizarStatusProduto(
+                            produto.id, !produto.isAtivo);
                       },
                     );
                   },

--- a/lib/presentation/gestao_produtos/gestao_state.dart
+++ b/lib/presentation/gestao_produtos/gestao_state.dart
@@ -1,5 +1,5 @@
-import '../../domain/entities/categoria.dart';
-import '../../domain/entities/produto.dart';
+import 'package:precifica/domain/entities/categoria.dart';
+import 'package:precifica/domain/entities/produto.dart';
 
 /// Representa todos os possíveis estados da tela de gestão.
 class GestaoState {

--- a/lib/presentation/gestao_produtos/widgets/categoria_nav_bar.dart
+++ b/lib/presentation/gestao_produtos/widgets/categoria_nav_bar.dart
@@ -4,7 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 // Importa a entidade Categoria da camada de domínio
-import '../../../domain/entities/categoria.dart';
+import 'package:precifica/domain/entities/categoria.dart';
 
 // Importa o controller da camada de apresentação
 import '../gestao_controller.dart';

--- a/lib/presentation/gestao_produtos/widgets/item_produto.dart
+++ b/lib/presentation/gestao_produtos/widgets/item_produto.dart
@@ -4,23 +4,24 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 // Importa a entidade Produto da camada de domínio
-import '../../../domain/entities/produto.dart';
+import 'package:precifica/domain/entities/produto.dart';
 
 // Importa o controller da camada de apresentação
 import '../gestao_controller.dart';
 
 // Importa os formatters da nova pasta de utilitários
-import '../../../app/core/utils/currency_formatter.dart';
-import '../../../app/core/utils/final_cursor_text_input_formatter.dart';
-
+import 'package:precifica/app/core/utils/currency_formatter.dart';
+import 'package:precifica/app/core/utils/final_cursor_text_input_formatter.dart';
 
 class ItemProduto extends ConsumerStatefulWidget {
   final Produto produto;
   final VoidCallback onDoubleTap;
+  final VoidCallback onTap;
 
   const ItemProduto({
     required this.produto,
     required this.onDoubleTap,
+    required this.onTap,
     super.key,
   });
 
@@ -42,10 +43,10 @@ class _ItemProdutoState extends ConsumerState<ItemProduto> {
     _precoController = InputCursorFinalController(
       text: formatter
           .formatEditUpdate(
-        TextEditingValue.empty,
-        TextEditingValue(
-            text: (widget.produto.preco * 100).toInt().toString()),
-      )
+            TextEditingValue.empty,
+            TextEditingValue(
+                text: (widget.produto.preco * 100).toInt().toString()),
+          )
           .text,
     );
   }
@@ -110,10 +111,18 @@ class _ItemProdutoState extends ConsumerState<ItemProduto> {
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final gestaoNotifier = ref.read(gestaoControllerProvider.notifier);
+    final isAtivo = widget.produto.isAtivo;
 
-    // A construção do conteúdo do item (ListTile) permanece a mesma
+    // A construção do conteúdo do item (ListTile)
     final itemContent = ListTile(
-      title: Text(widget.produto.nome),
+      title: Text(
+        widget.produto.nome,
+        style: TextStyle(
+          decoration:
+              isAtivo ? TextDecoration.none : TextDecoration.lineThrough,
+          color: isAtivo ? null : colorScheme.outline,
+        ),
+      ),
       trailing: SizedBox(
         width: 120,
         child: TextField(
@@ -135,7 +144,7 @@ class _ItemProdutoState extends ConsumerState<ItemProduto> {
               borderSide: BorderSide.none,
             ),
             contentPadding:
-            const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+                const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
           ),
           keyboardType: TextInputType.number,
           inputFormatters: [
@@ -184,6 +193,7 @@ class _ItemProdutoState extends ConsumerState<ItemProduto> {
         ),
         child: GestureDetector(
           onDoubleTap: widget.onDoubleTap,
+          onTap: widget.onTap,
           child: itemContent,
         ),
       ),

--- a/lib/presentation/gestao_produtos/widgets/item_produto.dart
+++ b/lib/presentation/gestao_produtos/widgets/item_produto.dart
@@ -3,13 +3,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-// Importa a entidade Produto da camada de domínio
 import 'package:precifica/domain/entities/produto.dart';
 
-// Importa o controller da camada de apresentação
 import '../gestao_controller.dart';
 
-// Importa os formatters da nova pasta de utilitários
 import 'package:precifica/app/core/utils/currency_formatter.dart';
 import 'package:precifica/app/core/utils/final_cursor_text_input_formatter.dart';
 
@@ -17,11 +14,17 @@ class ItemProduto extends ConsumerStatefulWidget {
   final Produto produto;
   final VoidCallback onDoubleTap;
   final VoidCallback onTap;
+  final FocusNode focusNode;
+  final VoidCallback onSubmitted;
+  final TextInputAction textInputAction;
 
   const ItemProduto({
     required this.produto,
     required this.onDoubleTap,
     required this.onTap,
+    required this.focusNode,
+    required this.onSubmitted,
+    required this.textInputAction,
     super.key,
   });
 
@@ -38,7 +41,6 @@ class _ItemProdutoState extends ConsumerState<ItemProduto> {
   @override
   void initState() {
     super.initState();
-    // A lógica de inicialização do controller do TextField permanece a mesma
     final formatter = MoedaFormatter();
     _precoController = InputCursorFinalController(
       text: formatter
@@ -59,7 +61,6 @@ class _ItemProdutoState extends ConsumerState<ItemProduto> {
     super.dispose();
   }
 
-  // A lógica de animação não precisa de alterações
   void _revertDragAnimation(Offset dragEndOffset, Widget feedback) {
     final RenderBox? renderBox = context.findRenderObject() as RenderBox?;
     if (renderBox == null || !renderBox.attached) return;
@@ -127,7 +128,10 @@ class _ItemProdutoState extends ConsumerState<ItemProduto> {
         width: 120,
         child: TextField(
           controller: _precoController,
+          focusNode: widget.focusNode,
           textAlign: TextAlign.right,
+          onSubmitted: (_) => widget.onSubmitted(),
+          textInputAction: widget.textInputAction,
           onChanged: (novoPrecoFormatado) {
             if (_debounce?.isActive ?? false) _debounce!.cancel();
             _debounce = Timer(const Duration(milliseconds: 500), () {

--- a/lib/presentation/gestao_produtos/widgets/item_produto.dart
+++ b/lib/presentation/gestao_produtos/widgets/item_produto.dart
@@ -45,10 +45,10 @@ class _ItemProdutoState extends ConsumerState<ItemProduto> {
     _precoController = InputCursorFinalController(
       text: formatter
           .formatEditUpdate(
-            TextEditingValue.empty,
-            TextEditingValue(
-                text: (widget.produto.preco * 100).toInt().toString()),
-          )
+        TextEditingValue.empty,
+        TextEditingValue(
+            text: (widget.produto.preco * 100).toInt().toString()),
+      )
           .text,
     );
   }
@@ -120,7 +120,7 @@ class _ItemProdutoState extends ConsumerState<ItemProduto> {
         widget.produto.nome,
         style: TextStyle(
           decoration:
-              isAtivo ? TextDecoration.none : TextDecoration.lineThrough,
+          isAtivo ? TextDecoration.none : TextDecoration.lineThrough,
           color: isAtivo ? null : colorScheme.outline,
         ),
       ),
@@ -148,7 +148,7 @@ class _ItemProdutoState extends ConsumerState<ItemProduto> {
               borderSide: BorderSide.none,
             ),
             contentPadding:
-                const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+            const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
           ),
           keyboardType: TextInputType.number,
           inputFormatters: [
@@ -172,33 +172,44 @@ class _ItemProdutoState extends ConsumerState<ItemProduto> {
       ),
     );
 
-    // A lógica do LongPressDraggable também permanece, pois o tipo `Produto`
-    // agora vem da entidade do domínio, que é o que o controller espera.
-    return Opacity(
-      opacity: _isReverting ? 0.0 : 1.0,
-      child: LongPressDraggable<Produto>(
-        data: widget.produto,
-        onDragStarted: () {
-          HapticFeedback.lightImpact();
-          gestaoNotifier.setDraggingProduto(true);
-        },
-        onDragEnd: (details) {
-          if (!details.wasAccepted && !_isReverting) {
-            gestaoNotifier.setDraggingProduto(false);
-          }
-        },
-        onDraggableCanceled: (velocity, offset) {
-          _revertDragAnimation(offset, feedbackWidget);
-        },
-        feedback: feedbackWidget,
-        childWhenDragging: Opacity(
-          opacity: 0.3,
-          child: itemContent,
-        ),
-        child: GestureDetector(
-          onDoubleTap: widget.onDoubleTap,
-          onTap: widget.onTap,
-          child: itemContent,
+    // O GestureDetector para onTap (reativar) agora envolve tudo.
+    return GestureDetector(
+      onTap: widget.onTap,
+      // Passa o comportamento de toque para os filhos se não houver conflito.
+      behavior: HitTestBehavior.translucent,
+      child: AnimatedOpacity(
+        duration: const Duration(milliseconds: 300),
+        opacity: isAtivo ? 1.0 : 0.4,
+        child: IgnorePointer(
+          ignoring: !isAtivo,
+          child: Opacity(
+            opacity: _isReverting ? 0.0 : 1.0,
+            child: LongPressDraggable<Produto>(
+              data: widget.produto,
+              onDragStarted: () {
+                HapticFeedback.lightImpact();
+                gestaoNotifier.setDraggingProduto(true);
+              },
+              onDragEnd: (details) {
+                if (!details.wasAccepted && !_isReverting) {
+                  gestaoNotifier.setDraggingProduto(false);
+                }
+              },
+              onDraggableCanceled: (velocity, offset) {
+                _revertDragAnimation(offset, feedbackWidget);
+              },
+              feedback: feedbackWidget,
+              childWhenDragging: Opacity(
+                opacity: 0.3,
+                child: itemContent,
+              ),
+              // O GestureDetector interno agora só lida com o doubleTap.
+              child: GestureDetector(
+                onDoubleTap: widget.onDoubleTap,
+                child: itemContent,
+              ),
+            ),
+          ),
         ),
       ),
     );

--- a/lib/presentation/gestao_produtos/widgets/product_list_view.dart
+++ b/lib/presentation/gestao_produtos/widgets/product_list_view.dart
@@ -1,17 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../domain/entities/produto.dart';
+import 'package:precifica/domain/entities/produto.dart';
 import '../gestao_controller.dart';
 import 'item_produto.dart';
 
 class ProductListView extends ConsumerWidget {
   final Function(Produto) onProdutoDoubleTap;
+  final Function(Produto) onProdutoTap;
   final String categoriaId;
 
   const ProductListView({
     super.key,
     required this.onProdutoDoubleTap,
+    required this.onProdutoTap,
     required this.categoriaId,
   });
 
@@ -62,6 +64,7 @@ class ProductListView extends ConsumerWidget {
           return ItemProduto(
             produto: produto,
             onDoubleTap: () => onProdutoDoubleTap(produto),
+            onTap: () => onProdutoTap(produto),
           );
         },
         separatorBuilder: (context, index) => const Divider(

--- a/lib/presentation/gestao_produtos/widgets/product_list_view.dart
+++ b/lib/presentation/gestao_produtos/widgets/product_list_view.dart
@@ -5,7 +5,7 @@ import 'package:precifica/domain/entities/produto.dart';
 import '../gestao_controller.dart';
 import 'item_produto.dart';
 
-class ProductListView extends ConsumerWidget {
+class ProductListView extends ConsumerStatefulWidget {
   final Function(Produto) onProdutoDoubleTap;
   final Function(Produto) onProdutoTap;
   final String categoriaId;
@@ -18,16 +18,70 @@ class ProductListView extends ConsumerWidget {
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final produtos = ref.watch(gestaoControllerProvider.select(
-            (state) => state.produtos));
+  ConsumerState<ProductListView> createState() => _ProductListViewState();
+}
+
+class _ProductListViewState extends ConsumerState<ProductListView> {
+  late List<FocusNode> _focusNodes;
+  late List<Produto> _produtos;
+
+  @override
+  void initState() {
+    super.initState();
+    _produtos =
+        ref.read(gestaoControllerProvider.select((state) => state.produtos));
+    _focusNodes = List.generate(_produtos.length, (index) => FocusNode());
+  }
+
+  @override
+  void didUpdateWidget(covariant ProductListView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final newProdutos =
+    ref.watch(gestaoControllerProvider.select((state) => state.produtos));
+
+    // Apenas recria os FocusNodes se o número de produtos mudar
+    if (_produtos.length != newProdutos.length) {
+      _produtos = newProdutos;
+      _disposeFocusNodes();
+      _focusNodes = List.generate(_produtos.length, (index) => FocusNode());
+    }
+  }
+
+  void _disposeFocusNodes() {
+    for (var node in _focusNodes) {
+      node.dispose();
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposeFocusNodes();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final produtos =
+    ref.watch(gestaoControllerProvider.select((state) => state.produtos));
+
+    // Garante que temos a quantidade correta de FocusNodes
+    if (produtos.length != _focusNodes.length) {
+      // Usa um PostFrameCallback para evitar erros de build
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          setState(() {
+            _disposeFocusNodes();
+            _focusNodes = List.generate(produtos.length, (index) => FocusNode());
+          });
+        }
+      });
+    }
 
     final textTheme = Theme.of(context).textTheme;
     final colorScheme = Theme.of(context).colorScheme;
 
     final gestaoState = ref.watch(gestaoControllerProvider);
 
-    // As mensagens para o usuário em caso de listas vazias não mudam.
     if (gestaoState.categorias.isEmpty) {
       return Center(
         child: Padding(
@@ -54,17 +108,34 @@ class ProductListView extends ConsumerWidget {
       );
     }
 
-    // A construção da ListView permanece idêntica.
+    // Se a lista de focus nodes estiver vazia (após deleção, por exemplo), não tenta construir a lista de produtos
+    if (produtos.isNotEmpty && _focusNodes.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8.0),
       child: ListView.separated(
         itemCount: produtos.length,
         itemBuilder: (context, index) {
           final produto = produtos[index];
+          final isLastItem = index == produtos.length - 1;
+
           return ItemProduto(
             produto: produto,
-            onDoubleTap: () => onProdutoDoubleTap(produto),
-            onTap: () => onProdutoTap(produto),
+            focusNode: _focusNodes[index],
+            onDoubleTap: () => widget.onProdutoDoubleTap(produto),
+            onTap: () => widget.onProdutoTap(produto),
+            textInputAction:
+            isLastItem ? TextInputAction.done : TextInputAction.next,
+            onSubmitted: () {
+              if (!isLastItem) {
+                FocusScope.of(context).requestFocus(_focusNodes[index + 1]);
+              } else {
+                FocusScope.of(context).unfocus();
+              }
+            },
           );
         },
         separatorBuilder: (context, index) => const Divider(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: precifica
 description: "Um aplicativo que ajuda na precificação de produtos."
 publish_to: 'none'
-version: 1.3.1+2
+version: 1.3.0+2
 
 environment:
   sdk: '>=3.4.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: precifica
 description: "Um aplicativo que ajuda na precificação de produtos."
 publish_to: 'none'
-version: 1.3.0+2
+version: 1.3.1+2
 
 environment:
   sdk: '>=3.4.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: precifica
 description: "Um aplicativo que ajuda na precificação de produtos."
 publish_to: 'none'
-version: 1.1.0+2
+version: 1.3.0+2
 
 environment:
   sdk: '>=3.4.0 <4.0.0'


### PR DESCRIPTION
## Novas Funcionalidades
- Adicionado suporte ao campo `isAtivo` em `Produto` e `ProdutoModel`.
- Implementado caso de uso `UpdateProdutoStatus` para ativar/inativar produtos.
- Agora é possível alternar o status de um produto com um simples toque na interface.
- Produtos inativos aparecem riscados, opacos e são ignorados em relatórios.

## Refatorações
- Reestruturada a relação entre `Categoria` e `Produto` utilizando `produtoIds` em `CategoriaModel`.
- Ajustada a navegação de produtos por categoria no repositório.
- Melhorado o refresh automático de produtos após criação, exclusão e atualização.
- Simplificado o carregamento e recarregamento de listas no `GestaoController`.

## UI/UX
- Produtos inativos aparecem com **texto tachado** e menor opacidade.
- Toque simples (`onTap`) alterna status do produto.
- Melhor feedback visual e integração com Riverpod.

## Relatórios
- Apenas produtos ativos são incluídos no relatório gerado pelo app.
